### PR TITLE
Fix Utf8View example: semicolon and return value

### DIFF
--- a/Chapters/01-zig-weird.qmd
+++ b/Chapters/01-zig-weird.qmd
@@ -1300,18 +1300,18 @@ character/unicode point in this string:
 #| eval: false
 const std = @import("std");
 const stdout = std.io.getStdOut().writer();
+
 pub fn main() !void {
-    var utf8 = (
-        (try std.unicode.Utf8View.init("アメリカ"))
-            .iterator()
-    );
-    while (utf8.nextCodepointSlice()) |codepoint| {
+    var utf8 = try std.unicode.Utf8View.init("アメリカ");
+    var iterator = utf8.iterator();
+    while (iterator.nextCodepointSlice()) |codepoint| {
         try stdout.print(
             "got codepoint {}\n",
-            .{std.fmt.fmtSliceHexUpper(codepoint)}
+            .{std.fmt.fmtSliceHexUpper(codepoint)},
         );
     }
 }
+
 ```
 
 ```


### PR DESCRIPTION
This PR fixes the example code for Utf8View iteration. It adds a missing semicolon and assigns the iterator's return value to a variable to avoid an ignored value error during compilation.