### PR TITLE
Fix: Add else branch to make the switch exhaustive

### DIFF
--- a/Chapters/03-structs.qmd
+++ b/Chapters/03-structs.qmd
@@ -282,15 +282,18 @@ switch statement two times, before ending at the `3` branch.
 #| auto_main: false
 #| build_type: "lib"
 #| eval: false
-xsw: switch (@as(u8, 1)) {
-    1 => {
-        try stdout.print("First branch\n", .{});
-        continue :xsw 2;
-    },
-    2 => continue :xsw 3,
-    3 => return,
-    4 => {},
-}
+    xsw: switch (@as(u8, 1)) {
+        1 => {
+            try stdout.print("First branch\n", .{});
+            continue :xsw 2;
+        },
+        2 => continue :xsw 3,
+        3 => return,
+        4 => {},
+        else => {
+            try stdout.print("Unmatched case, value: {d}\n", .{@as(u8, 1)});
+        },
+    }
 ```
 
 

--- a/Chapters/03-structs.qmd
+++ b/Chapters/03-structs.qmd
@@ -282,18 +282,20 @@ switch statement two times, before ending at the `3` branch.
 #| auto_main: false
 #| build_type: "lib"
 #| eval: false
-    xsw: switch (@as(u8, 1)) {
-        1 => {
-            try stdout.print("First branch\n", .{});
-            continue :xsw 2;
-        },
-        2 => continue :xsw 3,
-        3 => return,
-        4 => {},
-        else => {
-            try stdout.print("Unmatched case, value: {d}\n", .{@as(u8, 1)});
-        },
-    }
+xsw: switch (@as(u8, 1)) {
+    1 => {
+        try stdout.print("First branch\n", .{});
+        continue :xsw 2;
+    },
+    2 => continue :xsw 3,
+    3 => return,
+    4 => {},
+    else => {
+        try stdout.print(
+            "Unmatched case, value: {d}\n", .{@as(u8, 1)}
+        );
+    },
+}
 ```
 
 


### PR DESCRIPTION
The switch construct in Zig requires all possible cases to be covered for exhaustive checking. The original code lacks an else branch, causing a compile-time error for unhandled values. This PR adds an else branch to handle all unhandled cases and prevent errors.