### PR TITLE
Specify the CRAN mirror server in install.packages

### DIFF
--- a/dependencies.R
+++ b/dependencies.R
@@ -7,5 +7,5 @@ install.packages(
     "gt",
     "tibble"
   )
+  , repos = "http://cran.us.r-project.org"
 )
-

--- a/dependencies.R
+++ b/dependencies.R
@@ -7,5 +7,6 @@ install.packages(
     "gt",
     "tibble"
   )
-  , repos = "http://cran.us.r-project.org"
+  , repos = "https://cloud.r-project.org"
+
 )


### PR DESCRIPTION
As someone with no experience with R, I just installed R using:

`brew install --cask R`

and tried to run the script with:

`Rscript dependencies.R`

It threw the error:

```
Error in contrib.url(repos, "source") :
  trying to use CRAN without setting a mirror
Calls: install.packages -> contrib.url
Execution halted
```

Google told me that the repos parameter would tell R where to install the packages from, and this change fixed the script for me.

Thanks!