### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+	"name": "Debian",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {},
+		"ghcr.io/rocker-org/devcontainer-features/r-rig:1": {},
+		"ghcr.io/devcontainers-extra/features/zig:1": {}
+	},
+
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y librsvg2-bin && Rscript dependencies.R && Rscript -e \"install.packages('tinytex'); tinytex::install_tinytex()\""
+}


### PR DESCRIPTION
This commit introduces a new devcontainer configuration file (.devcontainer/devcontainer.json) that sets up a Debian-based development environment. The configuration includes features for Quarto CLI, R Rig, and Zig, along with a post-creation command to install necessary packages and dependencies.