### PR TITLE
Update 05-pointers.qmd

### DIFF
--- a/Chapters/05-pointers.qmd
+++ b/Chapters/05-pointers.qmd
@@ -250,13 +250,13 @@ the pointer with simple pointer arithmetic.
 
 ```{zig}
 #| eval: false
-const ar = [_]i32{1,2,3,4};
-var ptr = &ar;
-try stdout.print("{d}\n", .{ptr.*});
-ptr += 1;
-try stdout.print("{d}\n", .{ptr.*});
-ptr += 1;
-try stdout.print("{d}\n", .{ptr.*});
+    const ar = [_]i32{ 1, 2, 3, 4 };
+    var ptr: [*]const i32 = &ar; // Pointer to the first element
+    try stdout.print("{d}\n", .{ptr[0]});
+    ptr = ptr + 1; // Advance to the second element
+    try stdout.print("{d}\n", .{ptr[0]});
+    ptr = ptr + 1; // Advance to the third element
+    try stdout.print("{d}\n", .{ptr[0]});
 ```
 
 ```


### PR DESCRIPTION
Switched ptr to a multipointer ([*]const i32) to enable pointer arithmetic and element access using ptr[0], aligning with Zig's type-safe handling of arrays.

was facing errors in the executing of the code , asking on discord led me to the answer i.e. to use multi pointer

problem is type annotation of single pointer *const instead of a multipointer [*]const 