### PR TITLE
fix: Remove unnecessary swear word

### DIFF
--- a/Chapters/01-base64.qmd
+++ b/Chapters/01-base64.qmd
@@ -834,8 +834,8 @@ var fba = std.heap.FixedBufferAllocator.init(
 );
 const allocator = fba.allocator();
 
-const text = "Testing some more shit";
-const etext = "VGVzdGluZyBzb21lIG1vcmUgc2hpdA==";
+const text = "Testing some more stuff";
+const etext = "VGVzdGluZyBzb21lIG1vcmUgc3R1ZmY=";
 const base64 = Base64.init();
 const encoded_text = try base64.encode(
     allocator, text
@@ -852,8 +852,8 @@ try stdout.print(
 ```
 
 ```
-Encoded text: VGVzdGluZyBzb21lIG1vcmUgc2hpdA==
-Decoded text: Testing some more shit
+Encoded text: VGVzdGluZyBzb21lIG1vcmUgc3R1ZmY=
+Decoded text: Testing some more stuff
 ```
 
 You can also see the full source code at once, by visiting the official repository of this book[^repo].


### PR DESCRIPTION
While reading the physical book I came across an unnecessary swear word. Personally, I am not against swear words but this one felt unnecessary and makes the book feel less professional.

I updated both the string and base64 encoding.

Thank you for writing this book.

I assign the copyright of this contribution to Pedro Duarte Faria.