### PR TITLE
Change incorrect WebSocket reference to Unix sockets

### DIFF
--- a/Chapters/04-http-server.qmd
+++ b/Chapters/04-http-server.qmd
@@ -40,7 +40,7 @@ But the messages that are transmitted inside this connection are in a
 specific format. They are HTTP messages
 (i.e. messages that use the HTTP Protocol specification).
 The HTTP Protocol is the backbone of the modern web.
-The world wide web as we know it today, would not exist without the 
+The world wide web as we know it today, would not exist without the
 HTTP Protocol.
 
 So, Web servers (which is just a fancy name to
@@ -122,7 +122,7 @@ But I will describe the theory behind the necessary steps to create
 such HTTP server in C.
 
 
-In essence, we normally implement a HTTP server in C by using WebSocket technology,
+In essence, we normally implement a HTTP server in C by using the Unix socket abstraction,
 which involves the following steps:
 
 1. Create a socket object.
@@ -175,7 +175,7 @@ While the second component is a port number, which identifies the specific
 door, or, the specific port to use in the host machine.
 
 The sequence of 4 numbers (i.e. the host) identifies the machine (i.e. the computer itself) where
-this socket will live in. Every computer normally have multiple "doors" available inside of him, because 
+this socket will live in. Every computer normally have multiple "doors" available inside of him, because
 this allows the computer to receive and work with multiple connections at the same time.
 He simply use a single door for each connection. So the port number, is
 essentially a number that identifies the specific door in the computer that will be responsible
@@ -204,7 +204,7 @@ For TCP connections, which is our case here,
 a port number is a 16-bit unsigned integer (type `u16` in Zig),
 thus ranging from 0 to 65535 [@wikipedia_port].
 So, we can choose
-a number from 0 to 65535 for our port number. In the 
+a number from 0 to 65535 for our port number. In the
 example of this book, I will use the port number 3490
 (just a random number).
 


### PR DESCRIPTION
I believe that the reference to WebSockets is incorrect in the book. I think that this is not actually WebSockets but instead a standard Unix socket abstraction.

Normally, WebSockets is a protocol for establishing a two-way communication to a backend webserver (after performing a HTTP upgrade).

In the book, only the normal request and response flow is shown.

[1] https://en.wikipedia.org/wiki/WebSocket
[2] https://en.wikipedia.org/wiki/Berkeley_sockets#Socket_API_functions

Once again, thank you for writing this book.

 I assign the copyright of this contribution to Pedro Duarte Faria.