### PR TITLE
Fix typo in section 13.1

### DIFF
--- a/Chapters/12-file-op.qmd
+++ b/Chapters/12-file-op.qmd
@@ -68,7 +68,7 @@ This means that every program you write have a dedicated `stdin`, `stderr` and `
 from the `stdin`, `stderr` and `stdout` of other programs and processes that are currently running.
 
 This is a behaviour from your OS. This does not come from the programming language that you are using.
-Because as I sad earlier, input and output in programming languages, especially
+Because as I said earlier, input and output in programming languages, especially
 in high-level ones, are just a simple abstraction over the `stdin`, `stderr` and `stdout` from your current OS.
 That is, your OS is the intermediary between every input/output operation made in your program,
 regardless of the programming language that you are using.


### PR DESCRIPTION
In the last paragraph of section 13.1 it's mentioned as "Because as I sad earlier". Changing it to "Because as I said earlier".