### PR TITLE
Fix typo `an` -> `a`

### DIFF
--- a/Chapters/01-zig-weird.qmd
+++ b/Chapters/01-zig-weird.qmd
@@ -1400,7 +1400,7 @@ single byte (more precisely, an unsigned 8 bit integer - `u8`), that is why we h
 and also, you can see that this is a null-terminated array, because of the zero value after the `:` character in the data type.
 In other words, the string literal value exposed below is 16 bytes long.
 
-Now, if we create an pointer to the `simple_array` object, then, we get a constant pointer to an array of 4 elements (`*const [4]i32`),
+Now, if we create a pointer to the `simple_array` object, then, we get a constant pointer to an array of 4 elements (`*const [4]i32`),
 which is very similar to the type of the string literal value. This demonstrates that a string literal value
 in Zig is already a pointer to a null-terminated array of bytes.
 
@@ -1734,3 +1734,4 @@ Zig's syntax that are also equally important. Such as:
 - Unit tests in @sec-unittests;
 - Vectors in @sec-vectors-simd;
 - Build System in @sec-build-system;
+


### PR DESCRIPTION
I assign the copyright of this contribution to Pedro Duarte Faria