### PR TITLE
Update and pin the Nix book-building toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ foo.txt
 *.log
 *.toc
 
-flake.lock
-
 Chapters/15-vectors_files/
 
 **/*.quarto_ipynb

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782535326,
+        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "zig": "zig"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1782740553,
+        "narHash": "sha256-+1CTueOgAHoienOpWuSnvHICp7/4SuTloO3TDPO3zUA=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "b0e436f568101f6057008a123414396534a3bd38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,89 +1,103 @@
 {
-  description = "Dev shell for zig-book (HTML only) with Quarto, R, and user's Zig";
+  description = "Development environment for building the Zig book";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
-    zig.url = "github:mitchellh/zig-overlay";
+
+    zig = {
+      url = "github:mitchellh/zig-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, zig, ... } @ inputs:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      zig,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        # R packages needed by the book (from dependencies.R)
-        # and common ones for Quarto R execution.
-        rPkgsList = with pkgs.rPackages; [
-          quarto   # The R package 'quarto'
-          bslib
-          downlit
-          xml2     # Needs libxml2
-          gistr    # Might need curl
-          knitr    # Usually needed for R chunks in Quarto
-          rmarkdown # Often a dependency for knitr/Quarto R features
-          # Add other R packages if the book's R code uses more:
-          # e.g., readr, stringr, dplyr, fs, jsonlite, hms
-          readr
-          stringr
-          dplyr
-          fs
-          jsonlite
-          hms
-        ];
-
-        # R environment with the specified packages
-        R_env = pkgs.rWrapper.override {
-          packages = rPkgsList;
+        r = pkgs.rWrapper.override {
+          packages = with pkgs.rPackages; [
+            fs
+            knitr
+            readr
+            rmarkdown
+            stringr
+          ];
         };
 
-        # Native libraries that might be runtime dependencies for R packages
-        # or tools used by Quarto (excluding PDF-specific ones).
-        nativeDeps = with pkgs; [
-          libxml2 # For rPackages.xml2
-          curl    # For rPackages.gistr or other http functionality
-        ];
+        quartoVersion = "1.9.37";
+        quartoSources = {
+          aarch64-darwin = {
+            platform = "macos";
+            hash = "sha256-IX9WEFh0s4WKQlAdhMFdVaiFND2j9oUEYEbRtkWkH4Y=";
+          };
+          aarch64-linux = {
+            platform = "linux-arm64";
+            hash = "sha256-uz+PCIePXZF6JNB25e84uKgcLW/PQuSpAl3HdKCB7kQ=";
+          };
+          x86_64-darwin = {
+            platform = "macos";
+            hash = "sha256-IX9WEFh0s4WKQlAdhMFdVaiFND2j9oUEYEbRtkWkH4Y=";
+          };
+          x86_64-linux = {
+            platform = "linux-amd64";
+            hash = "sha256-ePzZDpg+Pn2+Pw0ZIcwQJTweynuSwg3UvCo8G8oKmvU=";
+          };
+        };
+        quartoSource = quartoSources.${system};
 
-        # REMOVED: localeDefinitions = pkgs.glibcLocalesUtf8;
-        # C.UTF-8 is generally available without needing full glibcLocales.
+        # Use Quarto's bundled toolchain so its Pandoc, Deno, and other
+        # dependencies always match the pinned Quarto release.
+        quarto = pkgs.stdenvNoCC.mkDerivation {
+          pname = "quarto";
+          version = quartoVersion;
 
-      in {
-        devShells.default = pkgs.mkShell {
-          # Packages made available in the shell environment
-          buildInputs = [
-            R_env       # Provides R and Rscript
-            pkgs.quarto # The Quarto CLI
-            zig.packages.${system}.master-2025-11-22
-            # REMOVED: localeDefinitions
-          ] ++ nativeDeps;
+          src = pkgs.fetchurl {
+            url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${quartoVersion}/quarto-${quartoVersion}-${quartoSource.platform}.tar.gz";
+            inherit (quartoSource) hash;
+          };
 
-          shellHook = ''
-            # QUARTO_R: Point Quarto to the Rscript from our Nix-provided R environment
-            unset QUARTO_R # Clear any pre-existing value
-            export QUARTO_R=$(which Rscript)
+          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            pkgs.autoPatchelfHook
+          ];
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            pkgs.openssl
+            pkgs.stdenv.cc.cc.lib
+            pkgs.zlib
+          ];
 
-            # --- GENERAL LOCALE SETUP ---
-            # Set a universally available, UTF-8 compatible locale.
-            # This prevents locale errors and ensures basic Unicode handling
-            # without imposing a specific language or requiring extra locale packages.
-            export LANG="C.UTF-8"
-            export LC_ALL="C.UTF-8"
-
-
-            echo "--- Nix Shell Environment (HTML Only) ---"
-            echo "Locale set to C.UTF-8 for broad compatibility." # Added this line for clarity
-            echo "Zig is assumed to be available via \$PATH: $(which zig || echo 'Not found zig in PATH')"
-            echo "R environment configured."
-            echo "  To check R's library paths: R -e '.libPaths()'"
-            echo "  To list R packages: R -e 'installed.packages()[,1]'"
-            echo "R environment is set to: $R_env"
-            echo "Rscript is at: $(which Rscript || echo 'Not found Rscript')"
-            echo "QUARTO_R set to: $QUARTO_R"
-            # REMOVED: echo "LOCALE_ARCHIVE set to: $LOCALE_ARCHIVE"
-            echo ""
-            echo "To build HTML: quarto render"
-            echo "-----------------------------------------"
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out"
+            cp -R . "$out"
+            runHook postInstall
           '';
+
+          meta.mainProgram = "quarto";
         };
-    });
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            quarto
+            r
+            zig.packages.${system}.master-2026-06-28
+          ];
+
+          LANG = "C.UTF-8";
+          LC_ALL = "C.UTF-8";
+
+          # Quarto expects the R executable, not Rscript.
+          QUARTO_R = "${r}/bin/R";
+        };
+      }
+    );
 }


### PR DESCRIPTION
## Summary

Update and make the Nix development environment reproducible:

- update `nixpkgs` from `nixos-24.05` to `nixos-26.05`;
- pin Zig to `master-2026-06-28`;
- pin Quarto to `1.9.37`;
- use Quarto's bundled Pandoc and Deno toolchain;
- configure `QUARTO_R` to point to the R executable;
- remove unused R dependencies and simplify the development shell;
- commit `flake.lock` instead of ignoring it.

## Context

PR #232 migrated the book examples to newer Zig APIs, but the Zig version in the Nix flake remained pinned to an older nightly. As a result, the current book sources could not be rendered through `nix develop`:

```shell
$ nix develop
warning: creating lock file "/home/obergodmar/Code/zig/zig-book/flake.lock":
• Added input 'flake-utils':
    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Added input 'nixpkgs':
    'github:NixOS/nixpkgs/b134951a4c9f3c995fd7be05f3243f8ecd65d798?narHash=sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8%3D' (2024-12-30)
• Added input 'zig':
    'github:mitchellh/zig-overlay/b0e436f568101f6057008a123414396534a3bd38?narHash=sha256-%2B1CTueOgAHoienOpWuSnvHICp7/4SuTloO3TDPO3zUA%3D' (2026-06-29)
• Added input 'zig/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
• Added input 'zig/nixpkgs':
    'github:NixOS/nixpkgs/3aadb7ca9eac2891d52a9dec199d9580a6e2bf44?narHash=sha256-O1XDr7EWbRp%2BkHrNNgLWgIrB0/US5wvw9K6RERWAj6I%3D' (2026-02-14)
• Added input 'zig/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
--- Nix Shell Environment (HTML Only) ---
Locale set to C.UTF-8 for broad compatibility.
Zig is assumed to be available via $PATH: /nix/store/bryjzisdykqzm189ypllzgy48h1k5grg-zig-0.16.0-dev.1441+2ea55d715/bin/zig
R environment configured.
  To check R's library paths: R -e '.libPaths()'
  To list R packages: R -e 'installed.packages()[,1]'
R environment is set to:
Rscript is at: /nix/store/jw97a4wrbnlry1js6l5w8g84ynwcp429-R-4.3.3-wrapper/bin/Rscript
QUARTO_R set to: /nix/store/jw97a4wrbnlry1js6l5w8g84ynwcp429-R-4.3.3-wrapper/bin/Rscript

To build HTML: quarto render
-----------------------------------------

[obergodmar@t14p:~/Code/zig/zig-book]$ quarto render
⚠️  The `--unstable` flag is deprecated and will be removed in Deno 2.0. Use granular `--unstable-*` flags instead.
Learn more at: https://docs.deno.com/runtime/manual/tools/unstable_flags
[ 1/19] index.qmd
⚠️  The `Deno.dlopen` API was used with `--unstable` flag. The `--unstable` flag is deprecated and will be removed in Deno 2.0. Use granular `--unstable-ffi` instead.
Learn more at: https://docs.deno.com/runtime/manual/tools/unstable_flags
[ 2/19] Chapters/01-zig-weird.qmd
[ 3/19] Chapters/03-structs.qmd
[ 4/19] Chapters/01-memory.qmd
[ 5/19] Chapters/01-base64.qmd
[ 6/19] Chapters/02-debugging.qmd
[ 7/19] Chapters/05-pointers.qmd
[ 8/19] Chapters/04-http-server.qmd
[ 9/19] Chapters/03-unittests.qmd
[10/19] Chapters/07-build-system.qmd
[11/19] Chapters/09-error-handling.qmd
[12/19] Chapters/09-data-structures.qmd
[13/19] Chapters/10-stack-project.qmd
[14/19] Chapters/12-file-op.qmd
WARNING: Specified QUARTO_R '/nix/store/2x401pa9z0gz96amjgn570lizryddv11-R-4.3.3-wrapper/bin/R:/nix/store/jw97a4wrbnlry1js6l5w8g84ynwcp429-R-4.3.3-wrapper/bin/Rscript' does not exist.


processing file: 12-file-op.qmd
1/35
2/35 [unnamed-chunk-1]
3/35
4/35 [unnamed-chunk-2]



Quitting from lines 147-157 [unnamed-chunk-2] (12-file-op.qmd)
Error in `generate_error_report()`:
! [ERROR]: An error was issued by the Zig compiler while trying to compile the Zig code block at 12-file-op.qmd:unnamed-chunk-2.
[ERROR]: The Zig compiler returned the following error message: /tmp/nix-shell.yHuYK7/RtmpFrtBb9/file1210f81f8426b4.zig:3:30: error: root source file struct 'process' has no member named 'Init'pub fn main(init: std.process.Init) !void {                  ~~~~~~~~~~~^~~~~/nix/store/bryjzisdykqzm189ypllzgy48h1k5grg-zig-0.16.0-dev.1441+2ea55d715/lib/std/process.zig:1:1: note: struct declared hereconst std = @import("std.zig");^~~~~referenced by:    callMain [inlined]: /nix/store/bryjzisdykqzm189ypllzgy48h1k5grg-zig-0.16.0-dev.1441+2ea55d715/lib/std/start.zig:701:46    callMainWithArgs [inlined]: /nix/store/bryjzisdykqzm189ypllzgy48h1k5grg-zig-0.16.0-dev.1441+2ea55d715/lib/std/start.zig:674:20    posixCallMainAndExit: /nix/store/bryjzisdykqzm189ypllzgy48h1k5grg-zig-0.16.0-dev.1441+2ea55d715/lib/std/start.zig:630:36    2 reference(s) hidden; use '-freference-trace=5' to see all references
[ERROR] The error was generated while trying to compile the following snippet of Zig code:
====== CODE COMPILED ============
const std = @import("std");
const Writer = std.Io.File.Writer;
pub fn main(init: std.process.Init) !void {
   var stdout_buffer: [1024]u8 = undefined;

   var stdout_writer = Writer.init(
       std.Io.File.stdout(),
       init.io,
       &stdout_buffer
   );

   const stdout = &stdout_writer.interface;
    var gpa = std.heap.DebugAllocator(.{}){};
    const allocator = gpa.allocator();

    var threaded: std.Io.Threaded = .init(allocator, .{});
    const io = threaded.io();
    defer threaded.deinit();
    _ = io;
_ = stdout;

}

=================================

[ERROR]: The output below is the backtrace from the R process:
Backtrace:
  1. global .main()
  2. execute(...)
  3. rmarkdown::render(...)
  4. knitr::knit(knit_input, knit_output, envir = envir, quiet = quiet)
  5. knitr:::process_file(text, output)
     ...
 12. knitr:::block_exec(params)
 15. global engine(options)
 16. global zig_build_lib(code, options)
 17. global zig_compile_file(file_path, "build-lib")
 18. global generate_error_report(file_path, output)
Warning message:
In system2(zig_cmd_path, c(zig_command, shQuote(file_path)), stdout = TRUE,  :
  running command ''/nix/store/bryjzisdykqzm189ypllzgy48h1k5grg-zig-0.16.0-dev.1441+2ea55d715/bin/zig' build-lib '/tmp/nix-shell.yHuYK7/RtmpFrtBb9/file1210f81f8426b4.zig' 2>&1' had status 1
Execution halted
WARNING: Specified QUARTO_R '/nix/store/2x401pa9z0gz96amjgn570lizryddv11-R-4.3.3-wrapper/bin/R:/nix/store/jw97a4wrbnlry1js6l5w8g84ynwcp429-R-4.3.3-wrapper/bin/Rscript' does not exist.
```

The flake also provided Quarto `1.4.554`, while the committed HTML output was generated with Quarto `1.9.37`. Rendering the book through the old environment therefore produced large unrelated changes in `docs/`.

Finally, `QUARTO_R` pointed to `Rscript`. Quarto expects the R executable, which resulted in an invalid path after processing by the Nix wrapper.

## Why Quarto is not taken from nixpkgs

The `quarto` package currently available in `nixos-26.05` does not preserve Quarto's bundled toolchain. It removes the bundled executables and replaces them with independently packaged versions from nixpkgs.

For Quarto `1.9.37`, this results in an incompatible combination:

- Quarto `1.9.37`;
- Pandoc `3.7.0.2` from nixpkgs.

Quarto `1.9.37` generates Pandoc configuration that is not supported by Pandoc `3.7.0.2`, causing rendering to fail with:

```text
Aeson exception: Error in $: Unknown option "syntax-highlighting"
```

The official Quarto 1.9.37 release includes Pandoc 3.8.3 and matching versions of Deno, Typst, Dart Sass, and the other tools it depends on. Quarto recommends using this bundled toolchain to avoid dependency version mismatches.

The flake therefore installs the official Quarto release archive instead of pkgs.quarto. Archive hashes are pinned for all supported platforms, and the Linux binaries are patched with autoPatchelfHook so they work correctly on NixOS.

This approach provides several benefits:

- Quarto and Pandoc are guaranteed to be compatible;
- the environment uses the same Quarto version that generated the committed HTML output;
- rendering does not produce large unrelated changes caused by switching between Quarto versions;
- the complete toolchain remains reproducible through the pinned archive hashes and flake.lock.

## Other implementation details

QUARTO_R now points to the R executable rather than Rscript, as expected by Quarto.

flake.lock is tracked so nixpkgs, zig-overlay, and the remaining flake inputs resolve to identical revisions across development environments.

Follow-up to #232.

## Verification

The resulting environment uses:

- Zig `0.17.0-dev.1099+7db2ef610`;
- Quarto `1.9.37`;
- Pandoc `3.8.3`;
- R `4.5.3`.

Verified with:

```shell
nix develop quarto render
```

All 19 chapters render successfully without the previous Zig, QUARTO_R, Deno, or Pandoc errors.